### PR TITLE
Fix posts overflowing on Safari on iOS

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -277,7 +277,7 @@ input[type="submit"]:hover { color: var(--accent); }
 .post_left, .post_right {
 	display: flex;
 	flex-direction: column;
-	overflow-wrap: anywhere;
+	overflow-wrap: break-word;
 }
 
 .post_left {


### PR DESCRIPTION
In Safari, the value `anywhere` is not supported for property `overflow-wrap`. Once changed to `break-word`, it behaves like it does in Chrome and Firefox.