### PR TITLE
Break word to stop it disappearing on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -314,6 +314,10 @@ input[type="submit"]:hover { color: var(--accent); }
 
 /* Post */
 
+.thread {
+	word-break: break-word;
+}
+
 .post {
 	border-radius: 5px;
 	background: var(--post);


### PR DESCRIPTION
This kept happening to me but I couldn't reproduce it in the iPad Simulator. Finally got it nailed down and sorted.

Tested this on Safari (mobile and desktop), Firefox, and Edge browser.