### PR TITLE
Stop label from being long for joined subreddits

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -222,6 +222,13 @@ aside {
 
 /* Sorting and Search */
 
+.search_label {
+	max-width: 100px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 select {
 	background: var(--outside);
 	transition: 0.2s all;

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,7 +10,7 @@
 			{% if sub != "" %}
 			<div id="inside">
 				<input type="checkbox" name="restrict_sr" id="restrict_sr" {% if params.restrict_sr != "" %}checked{% endif %}>
-				<label for="restrict_sr">in r/{{ sub }}</label>
+				<label for="restrict_sr" class="search_label">in r/{{ sub }}</label>
 			</div>
 			{% endif %}
 			<select id="sort_options" name="sort">

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -20,7 +20,7 @@
 	{% if root != "/r/" && !root.is_empty() %}
 	<div id="inside">
 		<input type="checkbox" name="restrict_sr" id="restrict_sr">
-		<label for="restrict_sr">in {{ root }}</label>
+		<label for="restrict_sr" class="search_label">in {{ root }}</label>
 	</div>
 	{% endif %}
 	<input type="submit" value="&rarr;">


### PR DESCRIPTION
Browsing with a long joined subreddit list will cause the label to look a bit weird.

Example: https://libredd.it/r/Android+AnimalsBeingBros+AnimalsBeingDerps+AnimalsBeingJerks+AppleWatch+CatSlaps+CatSmiles+CatsBeingAdorable+FreeTube+Games+Ijustwatched+IllegallySmol+IllegallySmolCats+IpodClassic+LearnRubyonRails+Megadrive+MovieDetails+Music+NetflixBestOf+NintendoSwitch+Possums+Teefers+UKPersonalFinance+airplaneears+apple+aww+brushybrushy+cats+catswhotrill+curledfeetsies+cyberpunkgame+dataisbeautiful+dechonkers+digital_ocean+dogs+dogsareliquid+dogswithjobs+emulation+greebles+happycowgifs+hardware+iOSDevelopment+iOSProgramming+iosdev+kittykankles+learnruby+likeus+mac+mashups+microsoft+movies+netflix+netsec+pihole+playstation+programming+rarepuppers+raspberry_pi+redditsync+rubyonrails+satelliteears+shittymoviedetails+spookyteefies+technology+teefies+vampirecats+velvethippos

That will cause the label to be excessively long