### PR TITLE
Fix the thumbnail issue on iOS

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -465,7 +465,6 @@ input[type="submit"]:hover { color: var(--accent); }
 
 .post_thumbnail img {
 	grid-area: 1 / 1 / 2 / 2;
-	height: 100%;
 	width: 100%;
 	object-fit: cover;
 	align-self: center;


### PR DESCRIPTION
Thumbnails were ridiculously long.

Tested this change on Firefox, Safari, and Edge.