### PR TITLE
Relative timestamps for posts younger than 24h

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -240,6 +240,7 @@ pub async fn fetch_posts(path: &str, fallback_title: String) -> Result<(Vec<Post
 		let score = post["data"]["score"].as_i64().unwrap_or_default();
 		let ratio: f64 = post["data"]["upvote_ratio"].as_f64().unwrap_or(1.0) * 100.0;
 		let title = val(post, "title");
+
 		// Determine the type of media along with the media URL
 		let (post_type, media) = media(&post["data"]).await;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -239,8 +239,7 @@ pub async fn fetch_posts(path: &str, fallback_title: String) -> Result<(Vec<Post
 		let unix_time: i64 = post["data"]["created_utc"].as_f64().unwrap_or_default().round() as i64;
 		let score = post["data"]["score"].as_i64().unwrap_or_default();
 		let ratio: f64 = post["data"]["upvote_ratio"].as_f64().unwrap_or(1.0) * 100.0;
-		let title = val(post, "title");	
-		
+		let title = val(post, "title");
 		// Determine the type of media along with the media URL
 		let (post_type, media) = media(&post["data"]).await;
 


### PR DESCRIPTION
Only affects the posts in the "subreddit" view, clicking the post still gives the full timestamp.

This is my first Rust project, so feedback is welcome.

![image](https://user-images.githubusercontent.com/8597693/104360496-72936780-5511-11eb-939d-661db2a37dd3.png)
