### PR TITLE
Improve support for text-only browsers

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -388,6 +388,10 @@ a.search_subreddit:hover {
 
 /* Post */
 
+.sep {
+	display: none;
+}
+
 .thread {
 	word-break: break-word;
 }

--- a/templates/post.html
+++ b/templates/post.html
@@ -98,11 +98,11 @@
 		<div class="thread">
 			<!-- EACH COMMENT -->
 			{% call comment(c) %}
-			<div class="replies">{% for reply1 in c.replies %}{% call comment(reply1) %}
+			<blockquote class="replies">{% for reply1 in c.replies %}{% call comment(reply1) %}
 				<!-- FIRST-LEVEL REPLIES -->
-				<div class="replies">{% for reply2 in reply1.replies %}{% call comment(reply2) %}
+				<blockquote class="replies">{% for reply2 in reply1.replies %}{% call comment(reply2) %}
 					<!-- SECOND-LEVEL REPLIES -->
-					<div class="replies">{% for reply3 in reply2.replies %}{% call comment(reply3) %}
+					<blockquote class="replies">{% for reply3 in reply2.replies %}{% call comment(reply3) %}
 						<!-- THIRD-LEVEL REPLIES -->
 						{% if reply3.replies.len() > 0 %}
 							<!-- LINK TO CONTINUE REPLIES -->
@@ -110,11 +110,11 @@
 						{% endif %}
 						{% call close() %}
 					{% endfor %}
-					</div>{% call close() %}
+					</blockquote>{% call close() %}
 				{% endfor %}
-				</div>{% call close() %}
+				</blockquote>{% call close() %}
 			{% endfor %}
-			</div>{% call close() %}
+			</blockquote>{% call close() %}
 		</div>
 		{%- endfor %}
 

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -31,6 +31,7 @@
 			<div id="posts">
 			{% for post in posts %}
 			{% if !(post.flags.nsfw && prefs.hide_nsfw == "on") %}
+			<hr class="sep" />
 			<div class="post {% if post.flags.stickied %}stickied{% endif %} {% if prefs.layout == "card" && post.post_type == "image" %}card_post{% endif %}">
 				<div class="post_left">
 					<p class="post_score">{{ post.score }}</p>


### PR DESCRIPTION
I'm not sure whether this is a target you're interested in supporting, but this PR improves the rendering of libreddit on many text-only browsers (or browsers without CSS enabled in general).

Adds hr's between posts to separate them (hidden by CSS, so the view remains the same on a graphical browser).

Use blockquotes to indent nested comments (Again, no impact on a graphical browser as far as I'm aware).

The blockquote trick successfully works on `w3m`, `links2` and `elinks`. It didn't work on `lynx`.

# Screenshots (w3m)

## Subreddit view (before/after)

![image](https://user-images.githubusercontent.com/8597693/104809454-a0b4c800-57ed-11eb-93ba-5c43ab4cba52.png) ![image](https://user-images.githubusercontent.com/8597693/104809425-7400b080-57ed-11eb-8342-bf4c8f2d76a8.png)

## Comments (before/after)
![image](https://user-images.githubusercontent.com/8597693/104809471-c215b400-57ed-11eb-8860-83f671917c2d.png) ![image](https://user-images.githubusercontent.com/8597693/104809418-5df2f000-57ed-11eb-9360-6b4e0793718c.png)
