### PR TITLE
Absolutly no jumping when images (fail to) load

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -522,30 +522,21 @@ a.search_subreddit:hover {
 }
 
 .post_media {
-	grid-area: post_media;
-	text-align: center;
-}
-
-.post_media img {
 	max-width: calc(100% - 40px);
+	height: auto;
+	align-self: center;
 	margin-top: 15px;
 	margin: 5px auto;
-	height: auto;
+	grid-area: post_media;
 	background-color: var(--highlighted);
-	display: block;
-	width: auto;
-	color: transparent;
-	/* TODO, add background image placeholder? */
-	/*
-	<svg viewBox="0 0 100 100" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
-	  <path d="M15,20 h70 a10,10 0 0 1 10,10 v40 a10,10 0 0 1 -10,10 h-70 a10,10 0 0 1 -10,-10 v-40 a10,10 0 0 1 10,-10 z" fill="none" stroke="RGBA(128,128,128,0.5)" stroke-width="5" />
-	  <path d="M15,70 l25,-35 l15,20 l10,-10 l20, 25 z" stroke="none" fill="RGBA(128,128,128,0.5)" />
-	</svg>
-	*/
+	background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 100 100' width='100' height='100' xmlns='http://www.w3.org/2000/svg'><path d='M15,20 h70 a10,10 0 0 1 10,10 v45 a10,10 0 0 1 -10,10 h-70 a10,10 0 0 1 -10,-10 v-45 a10,10 0 0 1 10,-10 z' fill='none' stroke='rgba(128,128,128,0.5)' stroke-width='3' /><path d='M15,75 l25,-35 l15,20 l10,-10 l20, 25 z' stroke='none' fill='rgba(128,128,128,0.5)' /><circle cx='75' cy='35' r='7' stroke='none' fill='rgba(128,128,128,0.5)'/></svg>");
+	background-position: 50%;
+	background-repeat: no-repeat;
 }
 
-.post_media img.short {
+.post_media.short {
 	max-height: 512px;
+	width: auto;
 }
 
 #post_url {
@@ -595,7 +586,7 @@ a.search_subreddit:hover {
 	margin: 5px;
 }
 
-.post_thumbnail img {
+.post_thumbnail svg {
 	grid-area: 1 / 1 / 2 / 2;
 	width: 100%;
 	height: auto;
@@ -608,7 +599,7 @@ a.search_subreddit:hover {
 	background-color: var(--highlighted);
 }
 
-.post_thumbnail svg {
+.post_thumbnail.no_thumbnail svg {
 	grid-area: 1 / 1 / 2 / 2;
 	align-self: center;
 	justify-self: center;

--- a/static/style.css
+++ b/static/style.css
@@ -522,14 +522,30 @@ a.search_subreddit:hover {
 }
 
 .post_media {
+	grid-area: post_media;
+	text-align: center;
+}
+
+.post_media img {
 	max-width: calc(100% - 40px);
-	align-self: center;
 	margin-top: 15px;
 	margin: 5px auto;
 	height: auto;
-	grid-area: post_media;
 	background-color: var(--highlighted);
-	display: table;
+	display: block;
+	width: auto;
+	color: transparent;
+	/* TODO, add background image placeholder? */
+	/*
+	<svg viewBox="0 0 100 100" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+	  <path d="M15,20 h70 a10,10 0 0 1 10,10 v40 a10,10 0 0 1 -10,10 h-70 a10,10 0 0 1 -10,-10 v-40 a10,10 0 0 1 10,-10 z" fill="none" stroke="RGBA(128,128,128,0.5)" stroke-width="5" />
+	  <path d="M15,70 l25,-35 l15,20 l10,-10 l20, 25 z" stroke="none" fill="RGBA(128,128,128,0.5)" />
+	</svg>
+	*/
+}
+
+.post_media img.short {
+	max-height: 512px;
 }
 
 #post_url {

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
 		{% block head %}
 		<title>{% block title %}Libreddit{% endblock %}</title>
 		<meta http-equiv="Referrer-Policy" content="no-referrer">
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; base-uri 'none'; form-action 'self';">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; base-uri 'none'; img-src 'self' data:; form-action 'self';">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<meta name="description" content="View on Libreddit, an alternative private front-end to Reddit.">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/post.html
+++ b/templates/post.html
@@ -61,7 +61,17 @@
 
 			<!-- POST MEDIA -->
 			{% if post.post_type == "image" %}
-			<img class="post_media" alt="Post image" width="{{ post.media.width }}px" height="{{ post.media.height}}px" src="{{ post.media.url }}"/>
+			<a href="{{ post.media.url }}" style="display:contents" >
+				<svg class="post_media" 
+					width="{{ post.media.width }}px" 
+					height="{{ post.media.height }}px" 
+					xmlns="http://www.w3.org/2000/svg">
+						<image width="100%" height="100%" href="{{ post.media.url }}"/>
+						<desc>
+							<img alt="Post image" src="{{ post.media.url }}"/>
+						</dev>
+				</svg>
+			</a>
 			{% else if post.post_type == "video" || post.post_type == "gif" %}
 			<video class="post_media" src="{{ post.media.url }}" controls autoplay loop></video>
 			{% else if post.post_type == "link" %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -60,16 +60,28 @@
 			</p>
 			<!-- POST MEDIA/THUMBNAIL -->
 			{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
-			<img class="post_media" alt="Post image" width="{{ post.media.width }}px" height="{{ post.media.height}}px" src="{{ post.media.url }}"/>
+			<a href="{{ post.media.url }}" style="display:contents" >
+				<svg class="post_media {% if post.media.height /  post.media.width < 2 %}short{% endif %}" 
+					width="{{ post.media.width }}px" 
+					height="{{ post.media.height }}px" 
+					xmlns="http://www.w3.org/2000/svg">
+						<image width="100%" height="100%" href="{{ post.media.url }}"/>
+						<desc>
+							<img alt="Post image" src="{{ post.media.url }}"/>
+						</dev>
+				</svg>
+			</a>
 			{% else if post.post_type != "self" %}
 			<a class="post_thumbnail {% if post.thumbnail.url.is_empty() %}no_thumbnail{% endif %}" href="{% if post.post_type == "link" %}{{ post.media.url }}{% else %}{{ post.permalink }}{% endif %}">
 				{% if post.thumbnail.url.is_empty() %}
-					<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
-						<title>Thumbnail</title>
-						<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
-					</svg>
+				<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
+					<title>Thumbnail</title>
+					<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
+				</svg>
 				{% else %}
-					<img src="{{ post.thumbnail.url }}" alt="Thumbnail" width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px">
+				<svg width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px" xmlns="http://www.w3.org/2000/svg">
+					<image  alt="Thumbnail" width="100%" height="100%" href="{{ post.thumbnail.url }}"/>
+				</svg>
 				{% endif %}
 				<span>{% if post.post_type == "link" %}{{ post.domain }}{% else %}{{ post.post_type }}{% endif %}</span>
 			</a>

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -55,16 +55,28 @@
 				</p>
 				<!-- POST MEDIA/THUMBNAIL -->
 				{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
-				<a href="{{ post.media.url }}" class="post_media" ><img  alt="Post image" width="{{ post.media.width }}px" height="{{ post.media.height }}px" src="{{ post.media.url }}" class="{% if post.media.height /  post.media.width < 3 %}short{% endif %}"/></a>
+				<a href="{{ post.media.url }}" style="display:contents" >
+					<svg class="post_media {% if post.media.height /  post.media.width < 2 %}short{% endif %}" 
+						width="{{ post.media.width }}px" 
+						height="{{ post.media.height }}px" 
+						xmlns="http://www.w3.org/2000/svg">
+							<image width="100%" height="100%" href="{{ post.media.url }}"/>
+							<desc>
+								<img alt="Post image" src="{{ post.media.url }}"/>
+							</dev>
+					</svg>
+				</a>
 				{% else if post.post_type != "self" %}
 				<a class="post_thumbnail {% if post.thumbnail.url.is_empty() %}no_thumbnail{% endif %}" href="{% if post.post_type == "link" %}{{ post.media.url }}{% else %}{{ post.permalink }}{% endif %}">
 					{% if post.thumbnail.url.is_empty() %}
-						<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
-							<title>Thumbnail</title>
-							<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
-						</svg>
+					<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
+						<title>Thumbnail</title>
+						<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
+					</svg>
 					{% else %}
-						<img src="{{ post.thumbnail.url }}" alt="Thumbnail" width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px">
+					<svg width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px" xmlns="http://www.w3.org/2000/svg">
+						<image  alt="Thumbnail" width="100%" height="100%" href="{{ post.thumbnail.url }}"/>
+					</svg>
 					{% endif %}
 					<span>{% if post.post_type == "link" %}{{ post.domain }}{% else %}{{ post.post_type }}{% endif %}</span>
 				</a>

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -55,7 +55,7 @@
 				</p>
 				<!-- POST MEDIA/THUMBNAIL -->
 				{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
-				<img class="post_media" alt="Post image" width="{{ post.media.width }}px" height="{{ post.media.height }}px" src="{{ post.media.url }}"/>
+				<a href="{{ post.media.url }}" class="post_media" ><img  alt="Post image" width="{{ post.media.width }}px" height="{{ post.media.height }}px" src="{{ post.media.url }}" class="{% if post.media.height /  post.media.width < 3 %}short{% endif %}"/></a>
 				{% else if post.post_type != "self" %}
 				<a class="post_thumbnail {% if post.thumbnail.url.is_empty() %}no_thumbnail{% endif %}" href="{% if post.post_type == "link" %}{{ post.media.url }}{% else %}{{ post.permalink }}{% endif %}">
 					{% if post.thumbnail.url.is_empty() %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -45,16 +45,28 @@
 				</p>
 				<!-- POST MEDIA/THUMBNAIL -->
 				{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
-				<img class="post_media" alt="Post image"  width="{{ post.media.width }}px" height="{{ post.media.height }}px" src="{{ post.media.url }}"/>
+				<a href="{{ post.media.url }}" style="display:contents" >
+					<svg class="post_media {% if post.media.height /  post.media.width < 2 %}short{% endif %}" 
+						width="{{ post.media.width }}px" 
+						height="{{ post.media.height }}px" 
+						xmlns="http://www.w3.org/2000/svg">
+							<image width="100%" height="100%" href="{{ post.media.url }}"/>
+							<desc>
+								<img alt="Post image" src="{{ post.media.url }}"/>
+							</dev>
+					</svg>
+				</a>
 				{% else if post.post_type != "self" %}
 				<a class="post_thumbnail {% if post.thumbnail.url.is_empty() %}no_thumbnail{% endif %}" href="{% if post.post_type == "link" %}{{ post.media.url }}{% else %}{{ post.permalink }}{% endif %}">
 					{% if post.thumbnail.url.is_empty() %}
-						<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
-							<title>Thumbnail</title>
-							<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
-						</svg>
+					<svg viewBox="0 0 100 106" width="140" height="53" xmlns="http://www.w3.org/2000/svg">
+						<title>Thumbnail</title>
+						<path d="M35,15h-15a10,10 0,0,0 0,20h25a10,10 0,0,0 10,-10m-12.5,0a10, 10 0,0,1 10, -10h25a10,10 0,0,1 0,20h-15" fill="none" stroke-width="5" stroke-linecap="round"/>
+					</svg>
 					{% else %}
-						<img src="{{ post.thumbnail.url }}" alt="Thumbnail" width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px">
+					<svg width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px" xmlns="http://www.w3.org/2000/svg">
+						<image  alt="Thumbnail" width="100%" height="100%" href="{{ post.thumbnail.url }}"/>
+					</svg>
 					{% endif %}
 					<span>{% if post.post_type == "link" %}{{ post.domain }}{% else %}{{ post.post_type }}{% endif %}</span>
 				</a>


### PR DESCRIPTION
Maybe I'm making all of this too complex 😅

* Tested on firefox and chrome
* Images have a max-height of 512px (expect when they are much longer than wide, because then they would become illegible)
* Images are clickable (direct link to image, for zooming)
* A placeholder image for loading/failed to load images (Chrome sadly overwrites it with an ugly, blurry icon though)