### PR TITLE
Make feed sorting case-insensitive

### DIFF
--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -95,7 +95,7 @@ pub async fn subscriptions(req: HttpRequest) -> HttpResponse {
 	// Modify sub list based on action
 	if action == "subscribe" && !sub_list.contains(&sub) {
 		sub_list.push(sub.to_owned());
-		sub_list.sort();
+		sub_list.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
 	} else if action == "unsubscribe" {
 		sub_list.retain(|s| s != &sub);
 	}


### PR DESCRIPTION
Sorting is currently case-sensitive in that it puts subs starting with an upper-case letter ahead of ones that start with a lower-case letter.

To reproduce:

- Subscribe to r/LineageOS
- Subscribe to r/fossdroid

LineageOS is placed before fossdroid.