### PR TITLE
Remove tiny "padding" below inline images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -641,10 +641,12 @@ a.search_subreddit:hover {
 	background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 100 100' width='100' height='100' xmlns='http://www.w3.org/2000/svg'><path d='M15,20 h70 a10,10 0 0 1 10,10 v45 a10,10 0 0 1 -10,10 h-70 a10,10 0 0 1 -10,-10 v-45 a10,10 0 0 1 10,-10 z' fill='none' stroke='rgba(128,128,128,0.5)' stroke-width='3' /><path d='M15,75 l25,-35 l15,20 l10,-10 l20, 25 z' stroke='none' fill='rgba(128,128,128,0.5)' /><circle cx='75' cy='35' r='7' stroke='none' fill='rgba(128,128,128,0.5)'/></svg>");
 	background-position: 50%;
 	background-repeat: no-repeat;
+	vertical-align: bottom;
 }
 
 .post_media_image img {
 	max-width: 100%;
+	vertical-align: bottom;
 }
 
 #post_url {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/8597693/106809132-9870df80-666b-11eb-8eb6-57ee7f27b5d9.png)

After
![image](https://user-images.githubusercontent.com/8597693/106809293-ca824180-666b-11eb-8ba7-b91adb372da6.png)
