### PR TITLE
Add more rich meta tags

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -10,7 +10,20 @@
 {% block root %}/r/{{ post.community }}{% endblock %}{% block location %}r/{{ post.community }}{% endblock %}
 {% block head %}
 	{% call super() %}
+	<!-- Meta Tags -->
 	<meta name="author" content="u/{{ post.author.name }}">
+	<meta name="title" content="{{ post.title }} - r/{{ post.community }}">
+	<meta name="description" content="View on Libreddit, an alternative private front-end to Reddit.">
+	<meta property="og:type" content="website">
+	<meta property="og:url" content="{{ post.permalink }}">
+	<meta property="og:title" content="{{ post.title }} - r/{{ post.community }}">
+	<meta property="og:description" content="View on Libreddit, an alternative private front-end to Reddit.">
+	<meta property="og:image" content="{{ post.thumbnail.url }}">
+	<meta property="twitter:card" content="summary_large_image">
+	<meta property="twitter:url" content="{{ post.permalink }}">
+	<meta property="twitter:title" content="{{ post.title }} - r/{{ post.community }}">
+	<meta property="twitter:description" content="View on Libreddit, an alternative private front-end to Reddit.">
+	<meta property="twitter:image" content="{{ post.thumbnail.url }}">
 {% endblock %}
 
 {% block subscriptions %}


### PR DESCRIPTION
I have added more metatags with the `ogp:` and `twitter:` prefix. 

I noticed that images weren't being shown in the embeds shown on Discord or Twitter.

You might have to add `https://libreddit.it` for the `:image` and `:url` metatags as it is just the relative path and the sites might not be able to locate it.