### PR TITLE
Added multi-staged container build and a user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ COPY --from=builder /usr/local/cargo/bin/libreddit /usr/local/bin/libreddit
 RUN useradd --system --user-group --home-dir /nonexistent --no-create-home --shell /usr/sbin/nologin libreddit
 USER libreddit
 
+EXPOSE 8080
+
 CMD ["libreddit"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM rust:latest
+FROM rust:latest as builder
 
 WORKDIR /usr/src/libreddit
 COPY . .
-
 RUN cargo install --path .
+
+
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -y libcurl4 && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/libreddit /usr/local/bin/libreddit
+RUN useradd --system --user-group --home-dir /nonexistent --no-create-home --shell /usr/sbin/nologin libreddit
+USER libreddit
 
 CMD ["libreddit"]


### PR DESCRIPTION
This reduces the image size from 2Gb to 92Mb by only put the necessary files into the container.
Container now runs without root priviliges. [see why](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user)

I hope all dependencies are added.