### PR TITLE
Add opensearch support

### DIFF
--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,11 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Search Libreddit</ShortName>
+  <Description>Search for whatever you want on Libreddit, awesome Reddit frontend</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="32" height="32" type="image/x-icon">/favicon.ico</Image>
+  <Url type="text/html" template="/search">
+    <Param name="q" value="{searchTerms}"/>
+  </Url>
+  <moz:SearchForm>/search</moz:SearchForm>
+</OpenSearchDescription>

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,8 @@
 		<meta name="mobile-web-app-capable" content="yes">
 		<!-- iOS Logo -->
 		<link href="/touch-icon-iphone.png" rel="apple-touch-icon">
+		<!-- OpenSearch description file -->
+		<link rel="search" type="application/opensearchdescription+xml" title="Search Libreddit" href="/opensearch.xml">
 		<!-- PWA Manifest -->
 		<link rel="manifest" type="application/json" href="/manifest.json">
 		<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico"> 


### PR DESCRIPTION
Hi,

It would be awesome to have opensearch support implemented in Libreddit!

[Docs](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for reference.

This PR adds basic OS support. However, I didn't tested it locally, so please check that it works as intended (especially relative links).

What this PR does not add: Search suggestions. They would be also cool, but it's not my technical stack. To add it, generating simple JSON is needed: [docs](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins). I guess new template would be needed here, similar to [search.html](https://github.com/spikecodes/libreddit/blob/master/templates/search.html).