### PR TITLE
Added laserwave theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -92,6 +92,21 @@
 	--highlighted: #3b4252;
 	--shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
+
+/* Laserwave theme setting */
+.laserwave {
+	--accent: #eb64b9;
+	--green: #74dfc4;
+	--text: #e0dfe1;
+	--foreground: #302a36;
+	--background: #27212e;
+	--outside: #3e3647;
+	--post: #3e3647;
+	--panel-border: 2px solid #2f2738;
+	--highlighted: #302a36;
+	--shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
 /* General */
 
 ::selection {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,7 +15,7 @@
 			<div id="theme">
 				<label for="theme">Theme:</label>
 				<select name="theme"> 
-					{% call utils::options(prefs.theme, ["system", "light", "dark", "black", "dracula", "nord"], "system") %}
+					{% call utils::options(prefs.theme, ["system", "light", "dark", "black", "dracula", "nord", "laserwave"], "system") %}
 				</select>
 			</div>
 			<p>Interface</p>


### PR DESCRIPTION
Hey @spikecodes! First off, wanted to say a big THANK YOU to your amazing work on this project! I use it practically on a daily basis, especially recently with one of the open-source projects that I use the most has started to really pick up its presence on its subreddit (r/neovim). Libreddit runs smoothly, looks so nice and clean, and just is a general joy to use. I've tried used old reddit, new reddit, various community skins on top of old reddit, and honestly never was happy with any of them. This project blows them out of the water, on top of being much more privacy friendly, which in and of itself is amazing. 

Anyways, I saw that a Dracula and Nord theme were added pretty recently, and figured I'd take a look at the PR that did that to see how hard it was to toss my hat in the ring with one of my favorite themes, [Laserwave](https://github.com/Jaredk3nt/laserwave). I saw that the PR was actually a really simple change, so figured I'd toss one in for my favorite theme, if you're willing to accept more themes. The image below is the result of my addition of Laserwave. If you're not interested in adding more themes or just not interested in adding this one, I'm happy to keep this tweak for my own usage. Thanks again for all your hard work on this project!

![laserwave in this PR](https://user-images.githubusercontent.com/37027883/116518653-0e2dc580-a8c0-11eb-8c22-363ac71a9c96.png)
