### PR TITLE
Add list of moderators to sidebar

### DIFF
--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -148,9 +148,7 @@ pub async fn wiki(req: Request<Body>) -> Result<Response<Body>, String> {
 	match json(path).await {
 		Ok(response) => template(WikiTemplate {
 			sub,
-			wiki: rewrite_urls(response["data"]["content_html"]
-                            .as_str()
-                            .unwrap_or("<h3>Wiki not found</h3>")),
+			wiki: rewrite_urls(response["data"]["content_html"].as_str().unwrap_or("<h3>Wiki not found</h3>")),
 			page,
 			prefs: Preferences::new(req),
 		}),
@@ -168,46 +166,47 @@ pub async fn sidebar(req: Request<Body>) -> Result<Response<Body>, String> {
 	match json(path).await {
 		// If success, receive JSON in response
 		Ok(response) => template(WikiTemplate {
-			wiki: format!("{}<hr><h1>Moderators</h1><br><ul>{}</ul>", 
-                            rewrite_urls(&val(&response, "description_html").replace("\\", "")),
-                            moderators(&sub).await?.join(""),
-                        ),
-                        sub,
+			wiki: format!(
+				"{}<hr><h1>Moderators</h1><br><ul>{}</ul>",
+				rewrite_urls(&val(&response, "description_html").replace("\\", "")),
+				moderators(&sub).await?.join(""),
+			),
+			sub,
 			page: "Sidebar".to_string(),
 			prefs: Preferences::new(req),
 		}),
 		Err(msg) => error(req, msg).await,
 	}
-
 }
 
 pub async fn moderators(sub: &str) -> Result<Vec<String>, String> {
-        // Retrieve and format the html for the moderators list
-        Ok(moderators_list(sub)
-            .await?
-            .iter()
-            .map(|m| format!("<li><a style=\"color: var(--accent)\" href=\"/u/{name}\">{name}</a></li>", name=m))
-            .collect()
-        )
+	// Retrieve and format the html for the moderators list
+	Ok(
+		moderators_list(sub)
+			.await?
+			.iter()
+			.map(|m| format!("<li><a style=\"color: var(--accent)\" href=\"/u/{name}\">{name}</a></li>", name = m))
+			.collect(),
+	)
 }
 
 async fn moderators_list(sub: &str) -> Result<Vec<String>, String> {
-    // Build the moderator list URL
-    let path: String = format!("/r/{}/about/moderators.json?raw_json=1", sub);
+	// Build the moderator list URL
+	let path: String = format!("/r/{}/about/moderators.json?raw_json=1", sub);
 
-    // Retrieve response
-    let response = json(path).await?["data"]["children"].clone();
-    Ok(if let Some(response) = response.as_array() {
-        // Traverse json tree and format into list of strings
-        response
-            .iter()
-            .map(|m| m["name"].as_str().unwrap_or(""))
-            .filter(|m| !m.is_empty())
-            .map(|m| m.to_string())
-            .collect::<Vec<_>>()
-    } else {
-        vec![]
-    })
+	// Retrieve response
+	let response = json(path).await?["data"]["children"].clone();
+	Ok(if let Some(response) = response.as_array() {
+		// Traverse json tree and format into list of strings
+		response
+			.iter()
+			.map(|m| m["name"].as_str().unwrap_or(""))
+			.filter(|m| !m.is_empty())
+			.map(|m| m.to_string())
+			.collect::<Vec<_>>()
+	} else {
+		vec![]
+	})
 }
 
 // SUBREDDIT
@@ -232,7 +231,7 @@ async fn subreddit(sub: &str) -> Result<Subreddit, String> {
 				title: esc!(&res, "title"),
 				description: esc!(&res, "public_description"),
 				info: rewrite_urls(&val(&res, "description_html").replace("\\", "")),
-                                moderators: moderators_list(sub).await?,
+				moderators: moderators_list(sub).await?,
 				icon: format_url(&icon),
 				members: format_num(members),
 				active: format_num(active),

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -148,7 +148,9 @@ pub async fn wiki(req: Request<Body>) -> Result<Response<Body>, String> {
 	match json(path).await {
 		Ok(response) => template(WikiTemplate {
 			sub,
-			wiki: rewrite_urls(response["data"]["content_html"].as_str().unwrap_or_default()),
+			wiki: rewrite_urls(response["data"]["content_html"]
+                            .as_str()
+                            .unwrap_or("<h3>Wiki not found</h3>")),
 			page,
 			prefs: Preferences::new(req),
 		}),
@@ -166,13 +168,46 @@ pub async fn sidebar(req: Request<Body>) -> Result<Response<Body>, String> {
 	match json(path).await {
 		// If success, receive JSON in response
 		Ok(response) => template(WikiTemplate {
-			sub,
-			wiki: rewrite_urls(&val(&response, "description_html").replace("\\", "")),
+			wiki: format!("{}<hr><h1>Moderators</h1><br><ul>{}</ul>", 
+                            rewrite_urls(&val(&response, "description_html").replace("\\", "")),
+                            moderators(&sub).await?.join(""),
+                        ),
+                        sub,
 			page: "Sidebar".to_string(),
 			prefs: Preferences::new(req),
 		}),
 		Err(msg) => error(req, msg).await,
 	}
+
+}
+
+pub async fn moderators(sub: &str) -> Result<Vec<String>, String> {
+        // Retrieve and format the html for the moderators list
+        Ok(moderators_list(sub)
+            .await?
+            .iter()
+            .map(|m| format!("<li><a style=\"color: var(--accent)\" href=\"/u/{name}\">{name}</a></li>", name=m))
+            .collect()
+        )
+}
+
+async fn moderators_list(sub: &str) -> Result<Vec<String>, String> {
+    // Build the moderator list URL
+    let path: String = format!("/r/{}/about/moderators.json?raw_json=1", sub);
+
+    // Retrieve response
+    let response = json(path).await?["data"]["children"].clone();
+    Ok(if let Some(response) = response.as_array() {
+        // Traverse json tree and format into list of strings
+        response
+            .iter()
+            .map(|m| m["name"].as_str().unwrap_or(""))
+            .filter(|m| !m.is_empty())
+            .map(|m| m.to_string())
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    })
 }
 
 // SUBREDDIT
@@ -197,6 +232,7 @@ async fn subreddit(sub: &str) -> Result<Subreddit, String> {
 				title: esc!(&res, "title"),
 				description: esc!(&res, "public_description"),
 				info: rewrite_urls(&val(&res, "description_html").replace("\\", "")),
+                                moderators: moderators_list(sub).await?,
 				icon: format_url(&icon),
 				members: format_num(members),
 				active: format_num(active),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -341,7 +341,7 @@ pub struct Subreddit {
 	pub title: String,
 	pub description: String,
 	pub info: String,
-        pub moderators: Vec<String>,
+	pub moderators: Vec<String>,
 	pub icon: String,
 	pub members: (String, String),
 	pub active: (String, String),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -341,6 +341,7 @@ pub struct Subreddit {
 	pub title: String,
 	pub description: String,
 	pub info: String,
+        pub moderators: Vec<String>,
 	pub icon: String,
 	pub members: (String, String),
 	pub active: (String, String),

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -99,7 +99,17 @@
 			</div>
 			<details class="panel" id="sidebar">
 				<summary id="sidebar_label">Sidebar</summary>
-				<div id="sidebar_contents">{{ sub.info }}</div>
+				<div id="sidebar_contents">
+                                  {{ sub.info }}
+                                  <hr>
+                                  <h2>Moderators</h2>
+                                  <br>
+                                  <ul>
+                                  {% for moderator in sub.moderators %}
+                                  <li><a style="color: var(--accent)" href="/u/{{ moderator }}">{{ moderator }}</a></li>
+                                  {% endfor %}
+                                  </ul>
+                                </div>
 			</details>
 		</aside>
 		{% endif %}


### PR DESCRIPTION
So I added a list of moderators in bullet points to the sidebar. Each item has a link to that users profile.

This PR closes issue no. #201 

![image](https://user-images.githubusercontent.com/11898833/116920707-e5545a00-ac4a-11eb-8c68-6f4152005cc7.png)
![image](https://user-images.githubusercontent.com/11898833/116920761-f1d8b280-ac4a-11eb-8bd9-84d870f8ee4f.png)

I also added in a message for when the wiki isn't found. This also fixes a UI rendering bug that makes everything bunch together in a ghastly fashion.
![image](https://user-images.githubusercontent.com/11898833/116921051-5a279400-ac4b-11eb-938a-27c92394a5f3.png)
