### PR TITLE
Added support for quarantined subreddits

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -75,6 +75,7 @@ fn request(url: String) -> Boxed<Result<Response<Body>, String>> {
 		.header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
 		.header("Accept-Language", "en-US,en;q=0.5")
 		.header("Connection", "keep-alive")
+		.header("Cookie", "_options=%7B%22pref_quarantine_optin%22%3A%20true%7D")
 		.body(Body::empty());
 
 	async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,10 @@ async fn main() {
 	app.at("/settings/update").get(|r| settings::update(r).boxed());
 
 	// Subreddit services
-	app.at("/r/:sub").get(|r| subreddit::community(r).boxed());
+	app
+		.at("/r/:sub")
+		.get(|r| subreddit::community(r).boxed())
+		.post(|r| subreddit::add_quarantine_exception(r).boxed());
 
 	app
 		.at("/r/u_:name")

--- a/src/post.rs
+++ b/src/post.rs
@@ -3,7 +3,7 @@ use crate::client::json;
 use crate::esc;
 use crate::server::RequestExt;
 use crate::subreddit::{can_access_quarantine, quarantine};
-use crate::utils::{cookie, error, format_num, format_url, param, rewrite_urls, setting, template, time, val, Author, Comment, Flags, Flair, FlairPart, Media, Post, Preferences};
+use crate::utils::{error, format_num, format_url, param, rewrite_urls, setting, template, time, val, Author, Comment, Flags, Flair, FlairPart, Media, Post, Preferences};
 
 use hyper::{Body, Request, Response};
 

--- a/src/post.rs
+++ b/src/post.rs
@@ -2,7 +2,7 @@
 use crate::client::json;
 use crate::esc;
 use crate::server::RequestExt;
-use crate::subreddit::quarantine;
+use crate::subreddit::{can_access_quarantine, quarantine};
 use crate::utils::{cookie, error, format_num, format_url, param, rewrite_urls, template, time, val, Author, Comment, Flags, Flair, FlairPart, Media, Post, Preferences};
 use hyper::{Body, Request, Response};
 
@@ -24,7 +24,8 @@ struct PostTemplate {
 pub async fn item(req: Request<Body>) -> Result<Response<Body>, String> {
 	// Build Reddit API path
 	let mut path: String = format!("{}.json?{}&raw_json=1", req.uri().path(), req.uri().query().unwrap_or_default());
-	let quarantined: bool = cookie(&req, "quarantine_exception").parse().unwrap_or(false);
+	let sub = req.param("sub").unwrap_or_default();
+	let quarantined = can_access_quarantine(&req, &sub);
 
 	// Set sort to sort query parameter
 	let mut sort: String = param(&path, "sort");

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 // CRATES
-use crate::utils::{catch_random, cookie, error, format_num, format_url, param, setting, template, val, Post, Preferences};
+use crate::utils::{catch_random, error, format_num, format_url, param, setting, template, val, Post, Preferences};
 use crate::{
 	client::json,
 	subreddit::{can_access_quarantine, quarantine},

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -127,7 +127,7 @@ pub fn quarantine(req: Request<Body>, sub: String) -> Result<Response<Body>, Str
 
 pub async fn add_quarantine_exception(req: Request<Body>) -> Result<Response<Body>, String> {
 	let subreddit = req.uri();
-	let redir: Vec<String> = subreddit.to_string().split("?redir=").into_iter().map(|s| s.to_string()).collect();
+	let redir: Vec<String> = subreddit.to_string().split("?redir=").into_iter().map(std::string::ToString::to_string).collect();
 	let subreddit: String = redir.first().ok_or("Invalid URL")?.chars().skip(3).collect();
 	let redir = redir.last().ok_or("Invalid URL")?;
 	let mut res = redirect(redir.to_owned());
@@ -143,7 +143,7 @@ pub async fn add_quarantine_exception(req: Request<Body>) -> Result<Response<Bod
 
 pub fn can_access_quarantine(req: &Request<Body>, sub: &str) -> bool {
 	// Determine if the subreddit can be accessed
-	cookie(&req, &format!("allow_quaran_{}", sub.to_lowercase())).parse().unwrap_or(false)
+	setting(&req, &format!("allow_quaran_{}", sub.to_lowercase())).parse().unwrap_or(false)
 }
 
 // Sub or unsub by setting subscription cookie using response "Set-Cookie" header

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -270,7 +270,7 @@ async fn subreddit(sub: &str) -> Result<Subreddit, String> {
 			let active: i64 = res["data"]["accounts_active"].as_u64().unwrap_or_default() as i64;
 
 			// Fetch subreddit icon either from the community_icon or icon_img value
-			let community_icon: &str = res["data"]["community_icon"].as_str().unwrap();
+			let community_icon: &str = res["data"]["community_icon"].as_str().unwrap_or_default();
 			let icon = if community_icon.is_empty() { val(&res, "icon_img") } else { community_icon.to_string() };
 
 			let sub = Subreddit {

--- a/src/user.rs
+++ b/src/user.rs
@@ -29,7 +29,7 @@ pub async fn profile(req: Request<Body>) -> Result<Response<Body>, String> {
 	);
 
 	// Retrieve other variables from Libreddit request
-	let sort = param(&path, "sort");
+	let sort = param(&path, "sort").unwrap_or_default();
 	let username = req.param("name").unwrap_or_default();
 
 	// Request user posts/comments from Reddit
@@ -44,8 +44,8 @@ pub async fn profile(req: Request<Body>) -> Result<Response<Body>, String> {
 			template(UserTemplate {
 				user,
 				posts,
-				sort: (sort, param(&path, "t")),
-				ends: (param(&path, "after"), after),
+				sort: (sort, param(&path, "t").unwrap_or_default()),
+				ends: (param(&path, "after").unwrap_or_default(), after),
 				prefs: Preferences::new(req),
 				url,
 			})

--- a/src/user.rs
+++ b/src/user.rs
@@ -33,7 +33,7 @@ pub async fn profile(req: Request<Body>) -> Result<Response<Body>, String> {
 	let username = req.param("name").unwrap_or_default();
 
 	// Request user posts/comments from Reddit
-	let posts = Post::fetch(&path, "Comment".to_string()).await;
+	let posts = Post::fetch(&path, "Comment".to_string(), false).await;
 	let url = String::from(req.uri().path_and_query().map_or("", |val| val.as_str()));
 
 	match posts {
@@ -61,7 +61,7 @@ async fn user(name: &str) -> Result<User, String> {
 	let path: String = format!("/user/{}/about.json?raw_json=1", name);
 
 	// Send a request to the url
-	match json(path).await {
+	match json(path, false).await {
 		// If success, receive JSON in response
 		Ok(res) => {
 			// Grab creation date as unix timestamp

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -416,11 +416,16 @@ impl Preferences {
 //
 
 // Grab a query parameter from a url
-pub fn param(path: &str, value: &str) -> String {
-	match Url::parse(format!("https://libredd.it/{}", path).as_str()) {
-		Ok(url) => url.query_pairs().into_owned().collect::<HashMap<_, _>>().get(value).unwrap_or(&String::new()).to_owned(),
-		_ => String::new(),
-	}
+pub fn param(path: &str, value: &str) -> Option<String> {
+	Some(
+		Url::parse(format!("https://libredd.it/{}", path).as_str())
+			.ok()?
+			.query_pairs()
+			.into_owned()
+			.collect::<HashMap<_, _>>()
+			.get(value)?
+			.to_owned(),
+	)
 }
 
 // Retrieve the value of a setting by name

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -217,12 +217,12 @@ pub struct Post {
 
 impl Post {
 	// Fetch posts of a user or subreddit and return a vector of posts and the "after" value
-	pub async fn fetch(path: &str, fallback_title: String) -> Result<(Vec<Self>, String), String> {
+	pub async fn fetch(path: &str, fallback_title: String, quarantine: bool) -> Result<(Vec<Self>, String), String> {
 		let res;
 		let post_list;
 
 		// Send a request to the url
-		match json(path.to_string()).await {
+		match json(path.to_string(), quarantine).await {
 			// If success, receive JSON in response
 			Ok(response) => {
 				res = response;
@@ -432,7 +432,7 @@ pub fn cookie(req: &Request<Body>, name: &str) -> String {
 // Detect and redirect in the event of a random subreddit
 pub async fn catch_random(sub: &str, additional: &str) -> Result<Response<Body>, String> {
 	if (sub == "random" || sub == "randnsfw") && !sub.contains('+') {
-		let new_sub = json(format!("/r/{}/about.json?raw_json=1", sub)).await?["data"]["display_name"]
+		let new_sub = json(format!("/r/{}/about.json?raw_json=1", sub), false).await?["data"]["display_name"]
 			.as_str()
 			.unwrap_or_default()
 			.to_string();

--- a/templates/wall.html
+++ b/templates/wall.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}{{ msg }}{% endblock %}
+{% block sortstyle %}{% endblock %}
+{% block content %}
+	<div id="wall">
+		<h1>{{ title }}</h1>
+                <br>
+		<p>{{ msg }}</p>
+                <form action="/r/{{ sub }}?redir={{ url }}" method="POST">
+			<input id="save" type="submit" value="Continue">
+                </form>
+	</div>
+{% endblock %}


### PR DESCRIPTION
Tricked Reddit into thinking that the ~~user~~ instance has opted in to viewing quarantined subreddits.

Closes #208

- [x] Find method to bypass quarantine block.
- [x] Implement cookie boolean in functions
- [x] Write wall template for quarantine
- [x] Add cookie
- [x] Ensure all routes work
    - [x] /r/sub
    - [x] /r/sub/subscribe
    - [x] /r/sub/unsubscribe
    - [x] /r/sub/comments/*
    - [x] /r/sub/search
    - [x] /r/sub/wiki/*
    - [x] /r/sub/about/sidebar
- [x] Fix feed bug
- [x] Add quarantine wall to posts
- [x] Fix case issue
