### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-docker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker-armv7.yml
+++ b/.github/workflows/docker-armv7.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-docker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-docker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-18.04
 
     steps:


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

GitHub provides a [feature](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) to set permissions for the GITHUB_TOKEN. I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically calculate the right permissions for a given workflow.  

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows.  

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. Please try it out on other repos and share your feedback. Thanks!