### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feel free to [open an issue](https://github.com/spikecodes/libreddit/issues/new)
 | [reddit.invak.id](https://reddit.invak.id) | 🇧🇬 BG |  |
 | [reddit.phii.me](https://reddit.phii.me) | 🇺🇸 US |  |
 | [lr.riverside.rocks](https://lr.riverside.rocks) | 🇺🇸 US |  |
-| [libreddit.silkky.cloud](https://libreddit.silkky.cloud) | 🇫🇮 FI |  |
+| [libreddit.silkky.cloud](https://libreddit.silkky.cloud) | 🇫🇮 FI | ✅ |
 | [libreddit.database.red](https://libreddit.database.red) | 🇺🇸 US | ✅ |
 | [libreddit.exonip.de](https://libreddit.exonip.de) | 🇩🇪 DE  |  |
 | [libreddit.domain.glass](https://libreddit.domain.glass) | 🇺🇸 US | ✅ |


### PR DESCRIPTION
Made a change for an instance's Cloudflare category. I'd been using their instance since so long but recently realized it's served through CF. So shifted to another instance.

A status column should be added to this instance list indicating a)their Libreddit version usage and b)up/down status. Several (listed below) are offline/defunct. Maybe like [this](https://github.com/zedeus/nitter/wiki/Instances) or better?

`libreddit.dothq.co`, `libreddit.40two.app`, `reddit.phii.me`, `libreddit.database.red`, `libreddit.sugoma.tk`, `libreddit.awesomehub.io`