### PR TITLE
Add the poster attribute even if a post claims to be type gif. Default to none-preloading for gifs like video-typed posts do.

### DIFF
--- a/templates/utils.html
+++ b/templates/utils.html
@@ -99,7 +99,7 @@
 		</svg>
 	</a>
 	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "gif" %}
-	<video class="post_media_video short" src="{{ post.media.url }}" width="{{ post.media.width }}" height="{{ post.media.height }}" poster="{{ post.media.poster }}" controls loop autoplay preload="none"><a href={{ post.media.url }}>Video</a></video>
+	<video class="post_media_video short" src="{{ post.media.url }}" width="{{ post.media.width }}" height="{{ post.media.height }}" poster="{{ post.media.poster }}" controls loop preload="none"><a href={{ post.media.url }}>Video</a></video>
 	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "video" %}
 	{% if prefs.use_hls == "on" && !post.media.alt_url.is_empty() %}
 	<video class="post_media_video short" width="{{ post.media.width }}" height="{{ post.media.height }}" poster="{{ post.media.poster }}" controls preload="none">
@@ -107,7 +107,7 @@
 		<source src="{{ post.media.url }}" type="video/mp4" />
 	</video>
 	{% else %}
-	<video class="post_media_video short" src="{{ post.media.url }}" width="{{ post.media.width }}" height="{{ post.media.height }}" poster="{{ post.media.poster }}" preload="none" controls autoplay><a href={{ post.media.url }}>Video</a></video>
+	<video class="post_media_video short" src="{{ post.media.url }}" width="{{ post.media.width }}" height="{{ post.media.height }}" poster="{{ post.media.poster }}" preload="none" controls><a href={{ post.media.url }}>Video</a></video>
 	{% call render_hls_notification(format!("{}%23{}", &self.url[1..].replace("&", "%26").replace("+", "%2B"), post.id)) %}
 	{% endif %}
 	{% else if post.post_type != "self" %}


### PR DESCRIPTION
Hello there! Firstly, thanks for libreddit, I've been using it extensively for the last weeks!

I'm also affected by #283 and started investigating. The best subreddit I know for testing this behaviour is (NSFW!) `r/60fpsporn`. Currently a sub like this is unusable via libreddit because it tries (pre-)loading ~100MBs of video data on page-load.

I went down the reddit JSON rabbit hole a bit, and am left wondering what the `is_gif` flag actually means. Example reddit data (from subreddit above):

```
{
  "reddit_video_preview": {
    "bitrate_kbps": 4800,
    "dash_url": "https://v.redd.it/xxx/DASHPlaylist.mpd",
    "duration": 59,
    "fallback_url": "https://v.redd.it/xxx/DASH_1080.mp4",
    "height": 1080,
    "hls_url": "https://v.redd.it/xxx/HLSPlaylist.m3u8",
    "is_gif": true,
    "scrubber_media_url": "https://v.redd.it/xxx/DASH_96.mp4",
    "transcoding_status": "completed",
    "width": 1920
  }
}
```

I see no reason why this preview would claim to be gif. 

As far as I can tell, in this case, in `utils.rs` the first attempt is to get the `fallback_url` (mp4), while `is_gif` is true which results in returning an mp4 and also `post_type="gif"`.

This PR proposes to add the `poster` for gifs (which is actually served for all gifs I have observed so far), and to disable preloading. Please give it a try on the sub above or any other "gif"-heavy subreddit. It works very well now, i.e. preview images are available and the page loads quickly (similar experience to vanilla reddit).

The PR negatively affects people that like auto-play for their gifs. E.g. when browsing r/all, I actually enjoy the auto-play sometimes. However, the current handling seems a bit arbitrary: no preload for vidoes, preload for posts that claim to be gifs but often are not really gifs. 

Ideally we would merge this and follow up with a setting for auto-play on various media types. I have never written Rust code though, so this is beyond my skills for now. Happy for any thoughts!

---

PS:\
Alternatives considered:

Get rid of the `"gif"` post_type in `utils.rs` entirely. I tried hard-coding this, and I think it broke previews somehow (but I would need to re-check). I don't think it serves any other purpose.

Note to self: debugging was done via edit in `utils.rs`:

```
let data = &post["data"];
println!("{}", data);
```
and in `utils.html`:
```
<!-- POST MEDIA/THUMBNAIL -->
<!-- TESTING: {{ post.post_type }} -->
```