### PR TITLE
Change healthcheck script to utilise "wget"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     ports:
       - 8080:8080
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/settings"]
+      test: ["CMD", "wget", "--spider", "-q", "--tries=1", "http://localhost:8080/settings"]
       interval: 5m
       timeout: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     ports:
       - 8080:8080
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/settings"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/settings"]
       interval: 5m
       timeout: 3s


### PR DESCRIPTION
Current healthcheck script in docker-compose.yml has an error cause by missing "curl".

This PR replaced "curl" with "wget" since Dockerfile(s) already use "wget --spider --q".