### PR TITLE
Fix "Follow" button not changing to "Unfollow"

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -70,7 +70,7 @@ async fn user(name: &str) -> Result<User, String> {
 
 		// Parse the JSON output into a User struct
 		User {
-			name: name.to_string(),
+			name: res["data"]["name"].as_str().unwrap_or(name).to_owned(),
 			title: esc!(about("title")),
 			icon: format_url(&about("icon_img")),
 			karma: res["data"]["total_karma"].as_i64().unwrap_or(0),


### PR DESCRIPTION
Currently, case sensitivity is broken when following a user. For example:

Notice how the URL contains "SPEZ" in all caps, and so does the "u/SPEZ" part on the right:
<img width="894" alt="Screen Shot 2021-11-12 at 4 19 08 PM" src="https://user-images.githubusercontent.com/2687718/141594751-1c9d785f-3f19-4463-9cf6-1ecfd86752a6.png">

You can change the case in the URL, and the sidebar will match it:
<img width="894" alt="Screen Shot 2021-11-12 at 4 19 21 PM" src="https://user-images.githubusercontent.com/2687718/141594816-02291860-66f0-416a-b518-1cfa7adb516f.png">

If I try to follow this user, the "Follow" button doesn't change to "Unfollow". Going into the settings page reveals why:
<img width="442" alt="Screen Shot 2021-11-12 at 4 23 01 PM" src="https://user-images.githubusercontent.com/2687718/141594884-b3da342c-1fde-490d-9e84-24a575e18b5d.png">

The case of the subscribed user and the case of the username in the URL don't match.

This PR fixes this by using the fetched username in the `User` struct instead of the provided name which can have arbitrary casing. With the fix applied:
<img width="897" alt="Screen Shot 2021-11-12 at 5 51 04 PM" src="https://user-images.githubusercontent.com/2687718/141599228-6cfb55ca-e8cc-4a52-ae7c-317277055e28.png">

And after following:
<img width="897" alt="Screen Shot 2021-11-12 at 5 51 17 PM" src="https://user-images.githubusercontent.com/2687718/141599233-09efc7cb-e0fd-443e-8a14-9e88bd701b06.png">

**Note:** This is only really an issue if you manually type in a user's URL with incorrect casing. If you click a link to a user's profile instead, the URL will have the correct casing, and so the user added to the subscriptions list will also have the correct casing.