### PR TITLE
Collapse (sticky) bot comments by default.

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -188,7 +188,7 @@ fn parse_comments(json: &serde_json::Value, post_link: &str, post_author: &str, 
 			// Many libreddit users do not wish to see this kind of comment by default.
 			// Reddit does not tell us which users are "bots", so a good heuristic is to
 			// collapse stickied moderator comments.
-			let is_moderator_comment = data["distinguished"].as_str().unwrap_or_default().to_string() == "moderator";
+			let is_moderator_comment = data["distinguished"].as_str().unwrap_or_default() == "moderator";
 			let is_stickied = data["stickied"].as_bool().unwrap_or_default();
 			let collapsed = is_moderator_comment && is_stickied;
 

--- a/src/post.rs
+++ b/src/post.rs
@@ -184,6 +184,14 @@ fn parse_comments(json: &serde_json::Value, post_link: &str, post_author: &str, 
 			let id = val(&comment, "id");
 			let highlighted = id == highlighted_comment;
 
+			// Many subreddits have a default comment posted about the sub's rules etc.
+			// Many libreddit users do not wish to see this kind of comment by default.
+			// Reddit does not tell us which users are "bots", so a good heuristic is to
+			// collapse stickied moderator comments.
+			let is_moderator_comment = data["distinguished"].as_str().unwrap_or_default().to_string() == "moderator";
+			let is_stickied = data["stickied"].as_bool().unwrap_or_default();
+			let collapsed = is_moderator_comment && is_stickied;
+
 			Comment {
 				id,
 				kind,
@@ -216,6 +224,7 @@ fn parse_comments(json: &serde_json::Value, post_link: &str, post_author: &str, 
 				edited,
 				replies,
 				highlighted,
+				collapsed,
 			}
 		})
 		.collect()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -334,6 +334,7 @@ pub struct Comment {
 	pub edited: (String, String),
 	pub replies: Vec<Comment>,
 	pub highlighted: bool,
+	pub collapsed: bool,
 }
 
 #[derive(Template)]

--- a/templates/comment.html
+++ b/templates/comment.html
@@ -8,7 +8,7 @@
 		<p class="comment_score" title="{{ score.1 }}">{{ score.0 }}</p>
 		<div class="line"></div>
 	</div>
-	<details class="comment_right" open>
+	<details class="comment_right" {% if collapsed == false %}open{% endif %}>
 		<summary class="comment_data">
 			<a class="comment_author {{ author.distinguished }} {% if author.name == post_author %}op{% endif %}" href="/user/{{ author.name }}">u/{{ author.name }}</a>
 			{% if author.flair.flair_parts.len() > 0 %}


### PR DESCRIPTION
Comments are considered bot comments if they are posted by a moderator and are stickied. Some false positives are expected.

See #306 for context. Happy to hear more/different opinions on this! As far as the code goes, I tested this PR on a local dev version, and it seems to work (see e.g. the link I provided in the issue for testing).