### PR TITLE
Format post and comment votes with a decimal place, like vanilla reddit does.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -535,12 +535,14 @@ pub fn rewrite_urls(input_text: &str) -> String {
 	})
 }
 
-// Append `m` and `k` for millions and thousands respectively
+// Format vote count to a string that will be displayed.
+// Append `m` and `k` for millions and thousands respectively, and
+// round to the nearest tenth.
 pub fn format_num(num: i64) -> (String, String) {
 	let truncated = if num >= 1_000_000 || num <= -1_000_000 {
-		format!("{}m", num / 1_000_000)
+		format!("{:.1}m", num as f64 / 1_000_000.0)
 	} else if num >= 1000 || num <= -1000 {
-		format!("{}k", num / 1_000)
+		format!("{:.1}k", num as f64 / 1_000.0)
 	} else {
 		num.to_string()
 	};
@@ -618,4 +620,33 @@ pub async fn error(req: Request<Body>, msg: String) -> Result<Response<Body>, St
 	.unwrap_or_default();
 
 	Ok(Response::builder().status(404).header("content-type", "text/html").body(body.into()).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::format_num;
+
+    #[test]
+    fn format_num_works() {
+        assert_eq!(
+			format_num(567),
+			("567".to_string(), "567".to_string())
+		);
+		assert_eq!(
+			format_num(1234),
+			("1.2k".to_string(), "1234".to_string())
+		);
+		assert_eq!(
+			format_num(1999),
+			("2.0k".to_string(), "1999".to_string())
+		);
+		assert_eq!(
+			format_num(1001),
+			("1.0k".to_string(), "1001".to_string())
+		);
+		assert_eq!(
+			format_num(1_999_999),
+			("2.0m".to_string(), "1999999".to_string())
+		);
+    }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -697,12 +697,12 @@ a.search_subreddit:hover {
 
 .post_score {
 	padding-top: 16px;
+	padding-left: 12px;
 	font-size: 13px;
 	font-weight: bold;
-	text-align: end;
 	color: var(--accent);
 	grid-area: post_score;
-	text-align: end;
+	text-align: center;
 	border-radius: 5px 0 0 5px;
 	transition: 0.2s background;
 }
@@ -712,7 +712,7 @@ a.search_subreddit:hover {
 } 
 
 .post_header {
-	margin: 15px 20px 5px 15px;
+	margin: 15px 20px 5px 12px;
 	grid-area: post_header;
 }
 
@@ -723,7 +723,7 @@ a.search_subreddit:hover {
 .post_title {
 	font-size: 16px;
 	line-height: 1.5;
-	margin: 5px 15px;
+	margin: 5px 15px 5px 12px;
 	grid-area: post_title;
 }
 
@@ -1070,7 +1070,7 @@ summary.comment_data {
 }
 
 .compact .post_header {
-	margin: 15px 15px 2.5px 15px;
+	margin: 15px 15px 2.5px 12px;
 	font-size: 14px;
 }
 


### PR DESCRIPTION
Before this change, a vote count of 1999 was displayed as 1k, which is a pretty big gap. The displayed count also differed from what Reddit does. Now, the behaviour is consistent.

Added some tests for format_num.

---

First time that I'm writing tests in Rust, using floats, etc. so please let me know if anything here seems wrong!

I'm not aware of an open bug that references this issue, but it has been on my todo list for some time. From personal testing, the change works in the default style/layout. For posts with 100k+ votes, the display is a bit border-line (literally), but it still looks okay-ish IMO.