### PR TITLE
Add text post previews.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -251,11 +251,20 @@ impl Post {
 			// Determine the type of media along with the media URL
 			let (post_type, media, gallery) = Media::parse(data).await;
 
+			// selftext is set for text posts when browsing a (sub)reddit.
+			// Do NOT use selftext_html, because we truncate this content
+			// in the template code, and using selftext_html might result
+			// in truncated html.
+			let mut body = rewrite_urls(&val(post, "selftext"));
+			if body == "" {
+				body = rewrite_urls(&val(post, "body_html"))
+			}
+
 			posts.push(Self {
 				id: val(post, "id"),
 				title: esc!(if title.is_empty() { fallback_title.clone() } else { title }),
 				community: val(post, "subreddit"),
-				body: rewrite_urls(&val(post, "body_html")),
+				body,
 				author: Author {
 					name: val(post, "author"),
 					flair: Flair {

--- a/static/style.css
+++ b/static/style.css
@@ -722,6 +722,7 @@ a.search_subreddit:hover {
 
 .post_title {
 	font-size: 16px;
+	font-weight: 500;
 	line-height: 1.5;
 	margin: 5px 15px;
 	grid-area: post_title;

--- a/static/style.css
+++ b/static/style.css
@@ -837,9 +837,14 @@ a.search_subreddit:hover {
 .post_body {
 	opacity: 0.9;
 	font-weight: normal;
-	margin: 5px 15px;
+	padding: 5px 15px;
 	grid-area: post_body;
 	width: calc(100% - 30px);
+}
+
+.post_preview {
+	mask-image: linear-gradient(180deg,#000 60%,transparent);
+	opacity: 0.8;
 }
 
 .post_footer {

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -130,6 +130,10 @@
 	{% endif %}
 
 	<div class="post_score" title="{{ post.score.1 }}">{{ post.score.0 }}<span class="label"> Upvotes</span></div>
+	<div class="post_body">
+		<!-- preview of selfposts when browsing subreddits -->
+		{{ post.body|truncate(1000) }}
+	</div>
 	<div class="post_footer">
 		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} comments">{{ post.comments.0 }} comments</a>
 	</div>

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -130,7 +130,7 @@
 	{% endif %}
 
 	<div class="post_score" title="{{ post.score.1 }}">{{ post.score.0 }}<span class="label"> Upvotes</span></div>
-	<div class="post_body">
+	<div class="post_body post_preview">
 		<!-- preview of selfposts when browsing subreddits -->
 		{{ post.body|truncate(1000) }}
 	</div>


### PR DESCRIPTION
Things seems to work, and I cannot find anything I'm breaking with this change. 
However, this change was hard because I got a bit confused between the two places we seem to be parsing similar things (utils.rs, and post.rs). Or maybe I was just tired.

The `post_body` class was chosen because it seems like it makes the `grid-template` magic work that I understand almost nothing about.

The [truncate](https://djc.github.io/askama/filters.html#truncate) value was chosen "randomly". The value is big enough to fit most posts while not making subreddit pages unusable. The bigger concern I had was that the new text preview content seems to squish the sidebar a bit much. For testing see e.g. `r/offmychest`.

As always, if you can see a better way to accomplish this, let me know!

Fixes #327.