### PR TITLE
Hide text post previews in Compact mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1084,6 +1084,10 @@ summary.comment_data {
 	margin: 2.5px 15px;
 }
 
+.compact .post_preview {
+	display: none;
+}
+
 .compact .post_media {
 	max-width: calc(100% - 30px);
 	margin: 2.5px auto;


### PR DESCRIPTION
Currently text previews (#328) are also shown in Compact mode.
On vanilla reddit text previews are not shown in what they call "Classic" mode which appears to be the same as Compact mode in libreddit.

With this minor change I added display none CSS to hide the post previews in Compact mode.