### PR TITLE
Render markdown correctly in text post previews by using selftext_html.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -251,11 +251,8 @@ impl Post {
 			// Determine the type of media along with the media URL
 			let (post_type, media, gallery) = Media::parse(data).await;
 
-			// selftext is set for text posts when browsing a (sub)reddit.
-			// Do NOT use selftext_html, because we truncate this content
-			// in the template code, and using selftext_html might result
-			// in truncated html.
-			let mut body = rewrite_urls(&val(post, "selftext"));
+			// selftext_html is set for text posts when browsing.
+			let mut body = rewrite_urls(&val(post, "selftext_html"));
 			if body == "" {
 				body = rewrite_urls(&val(post, "body_html"))
 			}

--- a/static/style.css
+++ b/static/style.css
@@ -843,9 +843,11 @@ a.search_subreddit:hover {
 	width: calc(100% - 30px);
 }
 
+/* Used only for text post preview */
 .post_preview {
 	mask-image: linear-gradient(180deg,#000 60%,transparent);
 	opacity: 0.8;
+	max-height: 500px;
 }
 
 .post_footer {
@@ -1223,7 +1225,6 @@ input[type="submit"] {
 
 .md table {
 	margin: 5px;
-	display: block;
 	overflow-x: auto;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -838,7 +838,7 @@ a.search_subreddit:hover {
 .post_body {
 	opacity: 0.9;
 	font-weight: normal;
-	padding: 5px 15px;
+	padding: 5px 15px 5px 12px;
 	grid-area: post_body;
 	width: calc(100% - 30px);
 }
@@ -847,7 +847,7 @@ a.search_subreddit:hover {
 .post_preview {
 	mask-image: linear-gradient(180deg,#000 60%,transparent);
 	opacity: 0.8;
-	max-height: 500px;
+	max-height: 250px;
 }
 
 .post_footer {

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -132,7 +132,7 @@
 	<div class="post_score" title="{{ post.score.1 }}">{{ post.score.0 }}<span class="label"> Upvotes</span></div>
 	<div class="post_body post_preview">
 		<!-- preview of selfposts when browsing subreddits -->
-		{{ post.body|truncate(1000) }}
+		{{ post.body }}
 	</div>
 	<div class="post_footer">
 		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} comments">{{ post.comments.0 }} comments</a>


### PR DESCRIPTION
I was mistakenly under the impression that we somehow render markdown ourselves, but turns out we just take whatever HTML reddit gives us, and we also need to do this for text previews.

Use CSS to limit the size of the previews instead of truncating in the template.

Fix table CSS.

---

Fixes #332.

For testing the table CSS, see e.g. `r/Cricket/comments/qytpct/match_thread_3rd_t20i_india_vs_new_zealand/`. I hope I'm not accidentally breaking anything else here.