### PR TITLE
Set sub and user descriptions to `overflow-wrap: anywhere`

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -365,6 +365,7 @@ aside {
 #user_description, #sub_description {
 	margin: 0 15px;
 	text-align: left;
+	overflow-wrap: anywhere;
 }
 
 #user_name, #user_description:not(:empty), #user_icon,


### PR DESCRIPTION
I noticed some subreddits have long descriptions with no word boundaries, which results in this:
![Screen Shot 2021-11-27 at 5 58 01 PM](https://user-images.githubusercontent.com/2687718/143724941-b53ea3a3-fb61-423e-ad7a-2e53f97149bc.png)

Using `overflow-wrap: anywhere` appears to fix this (disclaimer: I'm no CSS expert, so this may be the wrong way to fix it):
![Screen Shot 2021-11-27 at 5 57 26 PM](https://user-images.githubusercontent.com/2687718/143724953-f5c5ccc4-5cb1-4f45-b256-ec4228ad7bdf.png)


