### PR TITLE
Fix for escaped HTML in some search returns

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -47,7 +47,7 @@ struct SearchTemplate {
 // SERVICES
 pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 	let nsfw_results = if setting(&req, "show_nsfw") == "on" { "&include_over_18=on" } else { "" };
-	let path = format!("{}.json?{}{}", req.uri().path(), req.uri().query().unwrap_or_default(), nsfw_results);
+	let path = format!("{}.json?raw_json=1&{}{}", req.uri().path(), req.uri().query().unwrap_or_default(), nsfw_results);
 	let query = param(&path, "q").unwrap_or_default();
 
 	if query.is_empty() {


### PR DESCRIPTION
I just appended the raw_json flag to the search GET request in order to return the unescaped content_html from the reddit API during searches. This is such a minor and straightforward change, I can't see it having an impact on any other features or functionality.