### PR TITLE
docs: add the missing `AUTOPLAY_VIDEOS` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Assign a default value for each setting by passing environment variables to Libr
 | `SHOW_NSFW`             | `["on", "off"]`                                                                                     | `off`         |
 | `USE_HLS`               | `["on", "off"]`                                                                                     | `off`         |
 | `HIDE_HLS_NOTIFICATION` | `["on", "off"]`                                                                                     | `off`         |
+| `AUTOPLAY_VIDEOS`       | `["on", "off"]`                                                                                     | `off`         |
 
 ### Examples
 


### PR DESCRIPTION
This config was introduced in https://github.com/spikecodes/libreddit/commit/1d4ea50a457b7955e391dc526aa3228aeab222c0 , but missed from the documentation.