### PR TITLE
Harden Systemd configuration

### DIFF
--- a/contrib/libreddit.service
+++ b/contrib/libreddit.service
@@ -11,5 +11,27 @@ Environment=PORT=8080
 EnvironmentFile=-/etc/libreddit.conf
 ExecStart=/usr/bin/libreddit -a ${ADDRESS} -p ${PORT}
 
+# Hardening
+DeviceAllow=
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service ~@privileged ~@resources
+UMask=0077
+
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
These options increase the isolation of libreddit service.

I am not setting `CapabilityBoundingSet`and `AmbientCapabilities` to allow users to easily add `CAP_NET_BIND_SERVICE` to listen on ports less than 1024. I am not setting `PrivateUsers=yes` as a private user cannot have process capabilities on the host's user namespace and thus `CAP_NET_BIND_SERVICE` has no effect.

I have been running my instance with this configuration since August 2021 without any noticeable issue.

Thanks,