### PR TITLE
Wrap long post urls.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -884,6 +884,7 @@ a.search_subreddit:hover {
 	color: var(--accent);
 	margin: 5px 12px;
 	grid-area: post_media;
+	overflow-wrap: anywhere;
 }
 
 .post_body {


### PR DESCRIPTION
Like https://github.com/spikecodes/libreddit/commit/59043456ba507658f24e387fe4cb6fa75c5a99e4 but for post_url.

Example of breakage:
![x1](https://user-images.githubusercontent.com/93015331/159564029-347898aa-e779-47d2-aa2a-e2d0ec832409.png)

(source: `r/UkrainianConflict/comments/taa8l4/`)