### PR TITLE
Add keyboard shortcuts to PREV and NEXT links

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -92,13 +92,13 @@
 			{% if params.before != "" %}
 			<a href="?q={{ params.q }}&restrict_sr={{ params.restrict_sr }}
 				&sort={{ params.sort }}&t={{ params.t }}
-				&before={{ params.before }}">PREV</a>
+				&before={{ params.before }}" accesskey="r">P<span style="text-decoration: underline;">R</span>EV</a>
 			{% endif %}
 
 			{% if params.after != "" %}
 			<a href="?q={{ params.q }}&restrict_sr={{ params.restrict_sr }}
 				&sort={{ params.sort }}&t={{ params.t }}
-				&after={{ params.after }}">NEXT</a>
+				&after={{ params.after }}" accesskey="x">NE<span style="text-decoration: underline;">X</span>T</a>
 			{% endif %}
 		</footer>
 		{% endif %}

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -65,11 +65,11 @@
 
 			<footer>
 				{% if !ends.0.is_empty() %}
-				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&before={{ ends.0 }}">PREV</a>
+				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&before={{ ends.0 }}" accesskey="r">P<span style="text-decoration: underline;">R</span>EV</a>
 				{% endif %}
 
 				{% if !ends.1.is_empty() %}
-				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&after={{ ends.1 }}">NEXT</a>
+				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&after={{ ends.1 }}" accesskey="x">NE<span style="text-decoration: underline;">X</span>T</a>
 				{% endif %}
 			</footer>
 		</div>

--- a/templates/user.html
+++ b/templates/user.html
@@ -66,11 +66,11 @@
 
 			<footer>
 				{% if ends.0 != "" %}
-				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&before={{ ends.0 }}">PREV</a>
+				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&before={{ ends.0 }}" accesskey="r">P<span style="text-decoration: underline;">R</span>EV</a>
 				{% endif %}
 
 				{% if ends.1 != "" %}
-				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&after={{ ends.1 }}">NEXT</a>
+				<a href="?sort={{ sort.0 }}&t={{ sort.1 }}&after={{ ends.1 }}" accesskey="x">NE<span style="text-decoration: underline;">X</span>T</a>
 				{% endif %}
 			</footer>
 		</div>


### PR DESCRIPTION
Add keyboard shortcuts to PREV and NEXT links using the accesskey global attribute. Underlined letters indicate the key. NB: different browsers use different keystroke combinations to activate access key shortcuts. For example, Firefox on Mac uses ⌃⌥ + accesskey.