### PR TITLE
Fix "Post url contains non-ASCII characters" error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "futures-lite",
  "hyper",
  "hyper-rustls",
+ "percent-encoding",
  "regex",
  "route-recognizer",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cookie = "0.16.0"
 futures-lite = "1.12.0"
 hyper = { version = "0.14.18", features = ["full"] }
 hyper-rustls = "0.23.0"
+percent-encoding = "2.1.0"
 route-recognizer = "0.3.1"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use cached::proc_macro::cached;
 use futures_lite::{future::Boxed, FutureExt};
 use hyper::{body::Buf, client, Body, Request, Response, Uri};
+use percent_encoding::{percent_encode, CONTROLS};
 use serde_json::Value;
 use std::result::Result;
 
@@ -90,7 +91,7 @@ fn request(url: String, quarantine: bool) -> Boxed<Result<Response<Body>, String
 								.headers()
 								.get("Location")
 								.map(|val| {
-									let new_url = val.to_str().unwrap_or_default();
+									let new_url = percent_encode(val.as_bytes(), CONTROLS).to_string();
 									format!("{}{}raw_json=1", new_url, if new_url.contains('?') { "&" } else { "?" })
 								})
 								.unwrap_or_default()


### PR DESCRIPTION
This annoying bug has already been described here: #245.
(percent-encoding = "2.1.0" is already a dependency of url = "2.2.2").