### PR TITLE
Change localhost to 0.0.0.0 in contrib/libreddit.conf so that it doesnt complain about localhost not being a valid addr

### DIFF
--- a/contrib/libreddit.conf
+++ b/contrib/libreddit.conf
@@ -1,2 +1,2 @@
-ADDRESS=localhost
+ADDRESS=0.0.0.0
 PORT=12345


### PR DESCRIPTION
When i use this file with default localhost and start the service, libreddit panics and gives this error
`May 04 13:56:14 vern.cc libreddit[104899]: thread 'main' panicked at 'Cannot parse localhost:2501 as address (example format: 0.0.0.0:8080)', /home/libreddit/.cargo/registry/src/github.com-1ecc6299db9ec823/libred>`
using 0.0.0.0 instead fixed it for me