### PR TITLE
Let native elements use theme accent colour

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -177,6 +177,7 @@
 
 html, body, div, h1, h2, h3, h4, h5, h6, ul, ol, dl, li, dt, dd, p, blockquote,
 pre, form, fieldset, table, th, td, select, input {
+	accent-color: var(--accent);
 	margin: 0;
 	color: var(--text);
 	font-family: "Inter", sans-serif;


### PR DESCRIPTION
This PR makes all unstyled native elements like HTML checkboxes and inputs follow the theme's accent colour. See before/after below.

![Screenshot 2022-05-15 at 15 14 22](https://user-images.githubusercontent.com/42723993/168477264-27d8a552-b21c-4ce8-82e6-417c8d0c6caf.png)

![Screenshot 2022-05-15 at 15 14 05](https://user-images.githubusercontent.com/42723993/168477246-90699407-43fa-4385-a245-edc3db569a79.png)