### PR TITLE
Use singular form of "comment" for posts with 1 comment

### DIFF
--- a/templates/utils.html
+++ b/templates/utils.html
@@ -141,7 +141,7 @@
 		{{ post.body|safe }}
 	</div>
 	<div class="post_footer">
-		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} comments">{{ post.comments.0 }} comments</a>
+		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} comments">{{ post.comments.0 }} {% if post.comments.1 == "1" %}comment{% else %}comments{% endif %}</a>
 	</div>
 </div>
 {%- endmacro %}

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -141,7 +141,7 @@
 		{{ post.body|safe }}
 	</div>
 	<div class="post_footer">
-		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} comments">{{ post.comments.0 }} {% if post.comments.1 == "1" %}comment{% else %}comments{% endif %}</a>
+		<a href="{{ post.permalink }}" class="post_comments" title="{{ post.comments.1 }} {% if post.comments.1 == "1" %}comment{% else %}comments{% endif %}">{{ post.comments.0 }} {% if post.comments.1 == "1" %}comment{% else %}comments{% endif %}</a>
 	</div>
 </div>
 {%- endmacro %}


### PR DESCRIPTION
Use the singular of "comment" instead of the plural in the footer of posts with only one comment (i.e. "1 comment" instead of "1 comments").