### PR TITLE
feat: add a feature flag to enable the cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 askama = { version = "0.11.1", default-features = false }
 async-recursion = "1.0.0"
-cached = "0.40.0"
+cached = { version = "0.40.0", optional = true }
 clap = { version = "4.0.18", default-features = false, features = ["std"] }
 regex = "1.6.0"
 serde = { version = "1.0.147", features = ["derive"] }
@@ -25,3 +25,6 @@ tokio = { version = "1.21.2", features = ["full"] }
 time = "0.3.16"
 url = "2.3.1"
 rust-embed = { version = "6.4.2", features = ["include-exclude"] }
+
+[features]
+default = ["cached"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -112,7 +112,7 @@ fn request(url: String, quarantine: bool) -> Boxed<Result<Response<Body>, String
 }
 
 // Make a request to a Reddit API and parse the JSON response
-#[cached(size = 100, time = 30, result = true)]
+#[cfg_attr(feature = "cached", cached(size = 100, time = 30, result = true))]
 pub async fn json(path: String, quarantine: bool) -> Result<Value, String> {
 	// Build Reddit url from path
 	let url = format!("https://www.reddit.com{}", path);


### PR DESCRIPTION
Sometime, we may already have a cache strategy with varnish or squid.
In that case, the cache offered by libreddit will never hit and just slow down the request (hashmap check from the cached crate) and use more ram for nothing.