### PR TITLE
Remove Reddit's 'Nel' and 'Report-To' (network error logging) response headers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -104,6 +104,8 @@ async fn stream(url: &str, req: &Request<Body>) -> Result<Response<Body>, String
 			rm("x-cdn-server-region");
 			rm("x-reddit-cdn");
 			rm("x-reddit-video-features");
+			rm("Nel");
+			rm("Report-To");
 
 			res
 		})


### PR DESCRIPTION
Fixes: #830 by removing the `Nel` and `Report-To` response headers.

Validated changes by doing before-and-after loads of a sample reddit resource (an award image) as shown below.

### Before
![830_Before](https://github.com/libreddit/libreddit/assets/5759079/c23d1790-c0ea-43f1-97b5-e49f1adeeb39)

### After
![830_After](https://github.com/libreddit/libreddit/assets/5759079/b93fd9be-d6a2-461d-9db8-d9e2b5ac70aa)
